### PR TITLE
Suggested Bug Fix in postprocess.py

### DIFF
--- a/crocotools_py/postprocess.py
+++ b/crocotools_py/postprocess.py
@@ -496,7 +496,10 @@ def get_depths(ds):
         theta_b = ds.theta_b.values
     else: # it's a global attribute in CROCO files
         theta_b = ds.theta_b
-    hc = ds.hc.values
+    try:
+        hc = ds.hc.values
+    except:
+        hc = ds.hc
     N = np.shape(ds.s_rho)[0]
     type_coordinate = "rho"
     vtransform = ds.Vtransform.values

--- a/crocotools_py/postprocess.py
+++ b/crocotools_py/postprocess.py
@@ -496,9 +496,9 @@ def get_depths(ds):
         theta_b = ds.theta_b.values
     else: # it's a global attribute in CROCO files
         theta_b = ds.theta_b
-    try:
+    if 'hc' in ds.variables: # it's a variable in ROMS files
         hc = ds.hc.values
-    except:
+    else: # it's a global attribute in CROCO files
         hc = ds.hc
     N = np.shape(ds.s_rho)[0]
     type_coordinate = "rho"


### PR DESCRIPTION
I have included the folowing try and except block of code when reading the hc value in the get_var function in postprocess. 

Reading the hc value from our operational forecast runs using the get_var function works for files post 2024-08. Before 2024-08 it does not work and raises an error. I think this is because we changed the way the files are written in the operations. I therefore suggest the following try and except block which deals with both cases:

```python
try:
     hc = ds.hc.values
except:
     hc = ds.hc
```

I am obviously open to an alternative method that might be cleaner, but this does work. 